### PR TITLE
added a case statement to type switch handling BOOL typed properties

### DIFF
--- a/iActiveRecord/Classes/Column/ARColumn.mm
+++ b/iActiveRecord/Classes/Column/ARColumn.mm
@@ -134,6 +134,7 @@
         self->_associationPolicy = OBJC_ASSOCIATION_RETAIN_NONATOMIC;
         
         switch (anAttribute[0]) {
+            case _C_BOOL:
             case _C_CHR:     // BOOL, char
                 self->_columnType = ARColumnTypePrimitiveChar;
                 self.internal = new AR::CharColumn;


### PR DESCRIPTION
When trying out the new version i noticed that my app are not working anymore

Several error messages used to pop up in the log:
e.g., "Unsupported property type 'B' for column 'recurring' " for all BOOL typed columns.

It turned out that there was no dedicated handling of BOOL types in the ARColumn.mm. It did a quick fix that should keep things as close as they where up to now (bool columns are treated as char columns)

This change fixed the issue for me. Maybe there should be a little more specialized handling of bool columns ?
