### PR TITLE
fixed double values of decimals beeing returned as integers

### DIFF
--- a/iActiveRecord/Classes/ARRelationshipsHelper.h
+++ b/iActiveRecord/Classes/ARRelationshipsHelper.h
@@ -229,7 +229,7 @@
 #define field_decimal_imp( property_name ) \
     @dynamic property_name ;   \
     - (double) double_##property_name { \
-        NSInteger value =  [ [ self property_name ] integerValue ]; \
+        double value =  [ [ self property_name ] doubleValue ]; \
         return value; \
     }  \
     - (void) setDouble_##property_name: (double) value  { \


### PR DESCRIPTION
There was a serious copy & paste error causing decimal numbers to be truncated to intergers when the double_<column_name> methods where used
