### PR TITLE
fixed query results can not be mapped due to sqlite returning only vi…

### DIFF
--- a/iActiveRecord/Classes/ARLazyFetcher.m
+++ b/iActiveRecord/Classes/ARLazyFetcher.m
@@ -211,8 +211,9 @@
     NSString *fieldname = nil;
     for (NSString *field in [self recordFields]) {
         fieldname = [NSString stringWithFormat:
-                     @"\"%@\".\"%@\"",
+                     @"\"%@\".\"%@\" AS \"%@\"",
                      [recordClass tableName],
+                     field,
                      field];
         [fields addObject:fieldname];
     }


### PR DESCRIPTION
SQLITE does not return the column names for results that are based on database views if the column names aren't specified in the select statement.

This fix introduces an explicit naming for columns so that the right columns can be found in DB view models
